### PR TITLE
Fix std compiling issues

### DIFF
--- a/lib/test-xcorrelate.cc
+++ b/lib/test-xcorrelate.cc
@@ -34,7 +34,7 @@
 #include <math.h>  // fabsf
 #include <chrono>
 #include <ctime>
-
+#include <iomanip>
 #include "xcorrelate_impl.h"
 #include "xcorrelate_fft_vcf2_impl.h"
 


### PR DESCRIPTION
This fixes compiling issues about setprecision not being a member of 'std' on gcc 11 and higher